### PR TITLE
Update runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/iso_build.yaml
+++ b/.github/workflows/iso_build.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   prepare-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       -
         uses: styfle/cancel-workflow-action@0.9.0
@@ -20,7 +20,7 @@ jobs:
     outputs:
       release_tag: ${{ steps.time.outputs.time }}
   build-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [prepare-release]
     strategy:
       matrix:


### PR DESCRIPTION
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101